### PR TITLE
Change the liquid colour

### DIFF
--- a/app/library/styles/site.scss
+++ b/app/library/styles/site.scss
@@ -711,7 +711,7 @@ $headerHeight: 80px;
     $ferroColor2: black,
 
     $gasColor: rgb(200, 226, 255),
-    $liquidColor: rgb(100, 227, 252),
+    $liquidColor: rgb(100, 170, 197),
     $solidColor: #3F708B
 ){
 


### PR DESCRIPTION
This changes the liquid colour to be half way between the colour for solids and gases.

The previous choice of colour meant that liquids and gases only differed with a variation of the red portion of the colour (of around 100 points). This meant that I, being colourblind, was unable to see the difference between liquids and gases in the visualisation.

By having a larger difference in all three of the R, G and B values, it means that someone who is less sensitive to variations in a single aspect is more likely to be able to see the difference between the colours.

The choice of colour in this commit may be a tad ugly and want tweaking - it was chosen simply because it was roughly the midpoint.
